### PR TITLE
feat: Add contains and indexOf operations

### DIFF
--- a/src/ComposedSet/Common.fs
+++ b/src/ComposedSet/Common.fs
@@ -80,3 +80,34 @@ module Array =
         else
             false
 
+    /// <summary>
+    /// Checks if xs contains ys as a contiguous subsequence.
+    /// Returns the starting index if found, or -1 if not found.
+    /// </summary>
+    let inline indexOf (xs: 'a array) (ys: 'a array) : int =
+        let xs_length = Array.length xs
+        let ys_length = Array.length ys
+        if ys_length = 0 then 0
+        elif ys_length > xs_length then -1
+        else
+            let mutable found = -1
+            let mutable i = 0
+            while i <= xs_length - ys_length && found < 0 do
+                let mutable j = 0
+                let mutable matching = true
+                while j < ys_length && matching do
+                    if xs.[i + j] = ys.[j] then
+                        j <- j + 1
+                    else
+                        matching <- false
+                if matching then
+                    found <- i
+                else
+                    i <- i + 1
+            found
+
+    /// <summary>
+    /// Checks if xs contains ys as a contiguous subsequence.
+    /// </summary>
+    let inline contains xs ys = indexOf xs ys >= 0
+

--- a/src/ComposedSet/ComposedSet.fs
+++ b/src/ComposedSet/ComposedSet.fs
@@ -28,4 +28,15 @@ module ComposedSet =
                                 let indices' = Array.sub xs.indices (Array.length ys.indices) (Array.length xs.indices - Array.length ys.indices)
                                 {indices = indices'; hash = Array.calchash indices'}
                             else xs
-        
+
+    /// <summary>
+    /// Checks if xs contains ys as a contiguous subsequence.
+    /// Useful for finding patterns within decomposed paths/strings.
+    /// </summary>
+    let contains xs ys = Array.contains xs.indices ys.indices
+    
+    /// <summary>
+    /// Returns the index where ys first appears in xs, or -1 if not found.
+    /// </summary>
+    let indexOf xs ys = Array.indexOf xs.indices ys.indices
+


### PR DESCRIPTION
## Summary

Adds substring/subsequence search operations that complement the existing `startswith` and `endswith`.

## New Functions

### `Array.indexOf xs ys`
Returns the starting index where `ys` first appears in `xs`, or `-1` if not found.

### `Array.contains xs ys`
Returns `true` if `ys` appears anywhere in `xs`.

### `ComposedSet.indexOf xs ys` / `ComposedSet.contains xs ys`
Wrappers for the decomposed type.

## Use Case

```fsharp
// Find all files containing 'test' in their path
let testPattern = decompose "test"
files |> Array.filter (fun f -> ComposedSet.contains f testPattern)

// Find where '.cpp' appears in a path
let cppPattern = decompose ".cpp"
let idx = ComposedSet.indexOf somePath cppPattern
```

## Implementation

Uses a simple linear search with early termination. For large datasets with many searches, a more sophisticated algorithm (e.g., KMP) could be added later, but the current implementation is correct and sufficient for typical file system queries.

## Testing

✅ All existing tests pass